### PR TITLE
fix: typo on several subgraph templates

### DIFF
--- a/subgraphs/bentobox/template.yaml
+++ b/subgraphs/bentobox/template.yaml
@@ -18,7 +18,7 @@ dataSources:
       startBlock: {{ bentobox.startBlock }}
       abi: BentoBox
     mapping:
-      kind: ethereun/events
+      kind: ethereum/events
       apiVersion: 0.0.6
       language: wasm/assemblyscript
       file: ./src/mappings/bentobox.ts

--- a/subgraphs/blocks/template.yaml
+++ b/subgraphs/blocks/template.yaml
@@ -12,7 +12,7 @@ dataSources:
       startBlock: {{ blocks.startBlock }}
       abi: UniswapV2Factory
     mapping:
-      kind: ethereun/events
+      kind: ethereum/events
       apiVersion: 0.0.6
       language: wasm/assemblyscript
       file: ./src/mappings/blocks.ts

--- a/subgraphs/furo/template.yaml
+++ b/subgraphs/furo/template.yaml
@@ -90,7 +90,7 @@ dataSources:
       startBlock: {{ furo.stream.startBlock }}
       abi: BentoBox
     mapping:
-      kind: ethereun/events
+      kind: ethereum/events
       apiVersion: 0.0.6
       language: wasm/assemblyscript
       file: ./src/mappings/bentobox.ts

--- a/subgraphs/staking/template.yaml
+++ b/subgraphs/staking/template.yaml
@@ -12,7 +12,7 @@ dataSources:
       startBlock: {{ staking.startBlock }}
       abi: Staking
     mapping:
-      kind: ethereun/events
+      kind: ethereum/events
       apiVersion: 0.0.6
       language: wasm/assemblyscript
       file: ./src/mappings/staking.ts

--- a/subgraphs/trident/template.yaml
+++ b/subgraphs/trident/template.yaml
@@ -10,7 +10,7 @@ dataSources:
       startBlock: {{ trident.masterDeployer.startBlock }}
       abi: BentoBox
     mapping:
-      kind: ethereun/events
+      kind: ethereum/events
       apiVersion: 0.0.5
       language: wasm/assemblyscript
       file: ./src/mappings/bentobox.ts


### PR DESCRIPTION
**Description**
I noticed some of the subgraph templates had a typo on the value of the `kind` field, on the `mapping`. This PR fixes all the occurrences of the typo.