### PR TITLE
feat: add reduced V3 subgraph

### DIFF
--- a/subgraphs/v3-reduced/.gitignore
+++ b/subgraphs/v3-reduced/.gitignore
@@ -1,0 +1,1 @@
+schema.graft.graphql

--- a/subgraphs/v3-reduced/README.md
+++ b/subgraphs/v3-reduced/README.md
@@ -1,0 +1,70 @@
+# V3 Reduced Subgraph
+
+Reduced, data-api-focused SushiSwap V3 subgraph. It preserves pool discovery,
+TVL, volume, transaction entities, USD pricing, and pool/protocol time buckets
+while omitting position, tick, token-bucket, and fee-growth indexing.
+
+The package supports three builds from the same schema source:
+
+- `generate:immutable-graft` keeps event entities immutable and declares the
+  grafting feature. Goldsky has been verified to graft the mutable V3 entities
+  into this immutable schema and continue indexing without errors.
+- `generate:graft` creates a conservative fallback schema with mutable event
+  entities.
+- `generate` keeps event entities immutable. This is the clean deployment that
+  can sync independently without grafting.
+
+## Retained API
+
+- Current pools: token addresses/metadata, fee tier, liquidity, price, tick,
+  volume, TVL, transaction count, and protocol-fee status.
+- Immutable Mint, Burn, Swap, and Collect events with their existing field
+  names where data-api consumes them.
+- Pool hourly/daily buckets and protocol daily buckets for volume, fees, TVL,
+  and transaction counts.
+- Internal whitelist-pool pricing state used to derive USD values.
+
+## Removed indexing
+
+- NonfungiblePositionManager, Position, and PositionSnapshot.
+- Tick, TickDayData, and tick-crossing contract reads.
+- Pool and bucket fee-growth fields and their per-event contract reads.
+- TokenDayData and TokenHourData.
+- Flash, unused token aggregates, and unused pool/bucket fields.
+
+Swap handlers perform no contract calls. Pool creation reads `symbol()`,
+`name()`, `totalSupply()`, and `decimals()` once for each token that has
+not been indexed before.
+
+## Robinhood graft deployment
+
+Goldsky injects the graft base and block through `--graft-from`. The source is
+the currently deployed `sushiswap/v3-robinhood`; no deployment ID or block is
+stored in this repository.
+
+```sh
+NETWORK=robinhood pnpm --filter v3-reduced generate:immutable-graft
+pnpm --filter v3-reduced build
+goldsky subgraph deploy sushiswap/v3-reduced-robinhood \
+  --path subgraphs/v3-reduced \
+  --graft-from sushiswap/v3-robinhood
+```
+
+Without `--start-block`, Goldsky grafts from the latest indexed block of the
+source deployment.
+
+If immutable grafting is unavailable on another host, use `generate:graft`
+with the same deployment command to produce the mutable fallback.
+
+## Clean parallel deployment
+
+The clean deployment must have a distinct Goldsky version while both are
+running:
+
+```sh
+NETWORK=robinhood pnpm --filter v3-reduced generate
+pnpm --filter v3-reduced build
+goldsky subgraph deploy sushiswap/v3-reduced-robinhood-clean \
+  --path subgraphs/v3-reduced \
+  --remove-graft
+```

--- a/subgraphs/v3-reduced/abis/ERC20.json
+++ b/subgraphs/v3-reduced/abis/ERC20.json
@@ -1,0 +1,57 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/subgraphs/v3-reduced/abis/ERC20NameBytes.json
+++ b/subgraphs/v3-reduced/abis/ERC20NameBytes.json
@@ -1,0 +1,17 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/subgraphs/v3-reduced/abis/ERC20SymbolBytes.json
+++ b/subgraphs/v3-reduced/abis/ERC20SymbolBytes.json
@@ -1,0 +1,17 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/subgraphs/v3-reduced/abis/factory.json
+++ b/subgraphs/v3-reduced/abis/factory.json
@@ -1,0 +1,39 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token0",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token1",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint24",
+        "name": "fee",
+        "type": "uint24"
+      },
+      {
+        "indexed": false,
+        "internalType": "int24",
+        "name": "tickSpacing",
+        "type": "int24"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolCreated",
+    "type": "event"
+  }
+]

--- a/subgraphs/v3-reduced/abis/pool.json
+++ b/subgraphs/v3-reduced/abis/pool.json
@@ -1,0 +1,267 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "int24",
+        "name": "tickLower",
+        "type": "int24"
+      },
+      {
+        "indexed": true,
+        "internalType": "int24",
+        "name": "tickUpper",
+        "type": "int24"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "amount",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "name": "Burn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "int24",
+        "name": "tickLower",
+        "type": "int24"
+      },
+      {
+        "indexed": true,
+        "internalType": "int24",
+        "name": "tickUpper",
+        "type": "int24"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "amount0",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "amount1",
+        "type": "uint128"
+      }
+    ],
+    "name": "Collect",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "amount0",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "amount1",
+        "type": "uint128"
+      }
+    ],
+    "name": "CollectProtocol",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint160",
+        "name": "sqrtPriceX96",
+        "type": "uint160"
+      },
+      {
+        "indexed": false,
+        "internalType": "int24",
+        "name": "tick",
+        "type": "int24"
+      }
+    ],
+    "name": "Initialize",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "int24",
+        "name": "tickLower",
+        "type": "int24"
+      },
+      {
+        "indexed": true,
+        "internalType": "int24",
+        "name": "tickUpper",
+        "type": "int24"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "amount",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "name": "Mint",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "feeProtocol0Old",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "feeProtocol1Old",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "feeProtocol0New",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "feeProtocol1New",
+        "type": "uint8"
+      }
+    ],
+    "name": "SetFeeProtocol",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "amount0",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "amount1",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint160",
+        "name": "sqrtPriceX96",
+        "type": "uint160"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "liquidity",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "int24",
+        "name": "tick",
+        "type": "int24"
+      }
+    ],
+    "name": "Swap",
+    "type": "event"
+  }
+]

--- a/subgraphs/v3-reduced/package.json
+++ b/subgraphs/v3-reduced/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "v3-reduced",
+  "license": "MIT",
+  "repository": {
+    "url": "sushiswap/subgraphs",
+    "directory": "subgraphs/v3-reduced"
+  },
+  "files": [
+    "generated"
+  ],
+  "scripts": {
+    "generate": "node scripts/render.js clean && graph codegen",
+    "generate:graft": "node scripts/render.js graft && graph codegen",
+    "generate:immutable-graft": "node scripts/render.js immutable-graft && graph codegen",
+    "build": "graph build",
+    "test": "graph test -r",
+    "create-local": "graph create --node http://localhost:8020/ sushiswap/v3-reduced-robinhood",
+    "remove-local": "graph remove --node http://localhost:8020/ sushiswap/v3-reduced-robinhood",
+    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 sushiswap/v3-reduced-robinhood"
+  },
+  "devDependencies": {
+    "abi": "workspace:*",
+    "@graphprotocol/graph-cli": "^0.96.0",
+    "@graphprotocol/graph-ts": "^0.27.0",
+    "assemblyscript": "^0.19.20",
+    "matchstick-as": "0.5.0",
+    "wabt": "1.0.24"
+  }
+}

--- a/subgraphs/v3-reduced/schema.graphql
+++ b/subgraphs/v3-reduced/schema.graphql
@@ -1,0 +1,142 @@
+type Factory @entity {
+  id: ID!
+  txCount: BigInt!
+  totalVolumeUSD: BigDecimal!
+  untrackedVolumeUSD: BigDecimal!
+  totalFeesUSD: BigDecimal!
+  totalValueLockedUSD: BigDecimal!
+  totalValueLockedETH: BigDecimal!
+}
+
+type Bundle @entity {
+  id: ID!
+  ethPriceUSD: BigDecimal!
+}
+
+type Token @entity {
+  id: ID!
+  symbol: String!
+  name: String!
+  decimals: BigInt!
+  totalSupply: BigInt!
+  derivedETH: BigDecimal!
+  whitelistPools: [Pool!]!
+}
+
+type Pool @entity {
+  id: ID!
+  createdAtTimestamp: BigInt!
+  token0: Token!
+  token1: Token!
+  feeTier: BigInt!
+  liquidity: BigInt!
+  sqrtPrice: BigInt!
+  token0Price: BigDecimal!
+  token1Price: BigDecimal!
+  tick: BigInt
+  volumeUSD: BigDecimal!
+  txCount: BigInt!
+  totalValueLockedToken0: BigDecimal!
+  totalValueLockedToken1: BigDecimal!
+  totalValueLockedETH: BigDecimal!
+  totalValueLockedUSD: BigDecimal!
+  isProtocolFeeEnabled: Boolean!
+  poolHourData: [PoolHourData!]! @derivedFrom(field: "pool")
+  poolDayData: [PoolDayData!]! @derivedFrom(field: "pool")
+}
+
+type Transaction @entity(immutable: true) {
+  id: ID!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+  mints: [Mint!]! @derivedFrom(field: "transaction")
+  burns: [Burn!]! @derivedFrom(field: "transaction")
+  swaps: [Swap!]! @derivedFrom(field: "transaction")
+  collects: [Collect!]! @derivedFrom(field: "transaction")
+}
+
+type Mint @entity(immutable: true) {
+  id: ID!
+  transaction: Transaction!
+  timestamp: BigInt!
+  pool: Pool!
+  owner: Bytes!
+  sender: Bytes
+  origin: Bytes!
+  amount: BigInt!
+  amount0: BigDecimal!
+  amount1: BigDecimal!
+  amountUSD: BigDecimal
+  logIndex: BigInt
+}
+
+type Burn @entity(immutable: true) {
+  id: ID!
+  transaction: Transaction!
+  timestamp: BigInt!
+  pool: Pool!
+  owner: Bytes
+  origin: Bytes!
+  amount: BigInt!
+  amount0: BigDecimal!
+  amount1: BigDecimal!
+  amountUSD: BigDecimal
+  logIndex: BigInt
+}
+
+type Swap @entity(immutable: true) {
+  id: ID!
+  transaction: Transaction!
+  timestamp: BigInt!
+  pool: Pool!
+  sender: Bytes!
+  recipient: Bytes!
+  origin: Bytes!
+  amount0: BigDecimal!
+  amount1: BigDecimal!
+  amountUSD: BigDecimal!
+  sqrtPriceX96: BigInt!
+  logIndex: BigInt
+}
+
+type Collect @entity(immutable: true) {
+  id: ID!
+  transaction: Transaction!
+  timestamp: BigInt!
+  pool: Pool!
+  owner: Bytes
+  amount0: BigDecimal!
+  amount1: BigDecimal!
+  amountUSD: BigDecimal
+  logIndex: BigInt
+}
+
+type UniswapDayData @entity {
+  id: ID!
+  date: Int!
+  volumeUSD: BigDecimal!
+  volumeUSDUntracked: BigDecimal!
+  feesUSD: BigDecimal!
+  txCount: BigInt!
+  tvlUSD: BigDecimal!
+}
+
+type PoolDayData @entity {
+  id: ID!
+  date: Int!
+  pool: Pool!
+  tvlUSD: BigDecimal!
+  volumeUSD: BigDecimal!
+  feesUSD: BigDecimal!
+  txCount: BigInt!
+}
+
+type PoolHourData @entity {
+  id: ID!
+  periodStartUnix: Int!
+  pool: Pool!
+  tvlUSD: BigDecimal!
+  volumeUSD: BigDecimal!
+  feesUSD: BigDecimal!
+  txCount: BigInt!
+}

--- a/subgraphs/v3-reduced/scripts/render.js
+++ b/subgraphs/v3-reduced/scripts/render.js
@@ -1,0 +1,65 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const Mustache = require("mustache");
+
+const mode = process.argv[2] || "clean";
+const network = process.env.NETWORK;
+
+if (mode !== "clean" && mode !== "graft" && mode !== "immutable-graft") {
+  throw new Error(`Unknown render mode: ${mode}`);
+}
+
+if (!network || !/^[a-z0-9-]+$/.test(network)) {
+  throw new Error(
+    "NETWORK must name a config file, for example NETWORK=robinhood"
+  );
+}
+
+const packageRoot = path.resolve(__dirname, "..");
+const repositoryRoot = path.resolve(packageRoot, "../..");
+const configPath = path.join(repositoryRoot, "config", `${network}.js`);
+
+if (!fs.existsSync(configPath)) {
+  throw new Error(`Network config does not exist: ${configPath}`);
+}
+
+const config = require(configPath);
+const graft = mode !== "clean";
+const graftSchema = mode === "graft";
+const renderConfig = { ...config, graft, graftSchema };
+
+const template = fs.readFileSync(
+  path.join(packageRoot, "template.yaml"),
+  "utf8"
+);
+const constantsTemplate = fs.readFileSync(
+  path.join(packageRoot, "src/constants/index.template.ts"),
+  "utf8"
+);
+
+fs.writeFileSync(
+  path.join(packageRoot, "subgraph.yaml"),
+  Mustache.render(template, renderConfig)
+);
+fs.writeFileSync(
+  path.join(packageRoot, "src/constants/index.ts"),
+  Mustache.render(constantsTemplate, renderConfig)
+);
+
+if (graftSchema) {
+  const schemaPath = path.join(packageRoot, "schema.graphql");
+  const cleanSchema = fs.readFileSync(schemaPath, "utf8");
+  const immutableEntities =
+    cleanSchema.match(/@entity\(immutable: true\)/g) || [];
+
+  if (immutableEntities.length === 0) {
+    throw new Error(
+      "The clean schema has no immutable entities to make graft-compatible"
+    );
+  }
+
+  fs.writeFileSync(
+    path.join(packageRoot, "schema.graft.graphql"),
+    cleanSchema.replace(/@entity\(immutable: true\)/g, "@entity")
+  );
+}

--- a/subgraphs/v3-reduced/src/constants/index.template.ts
+++ b/subgraphs/v3-reduced/src/constants/index.template.ts
@@ -1,0 +1,24 @@
+import { BigInt, BigDecimal, Address } from "@graphprotocol/graph-ts";
+
+export const FACTORY_ADDRESS = Address.fromString("{{ v3.factory.address }}");
+export const NETWORK = "{{ network }}";
+
+export const ZERO_BI = BigInt.fromI32(0);
+export const ONE_BI = BigInt.fromI32(1);
+export const ZERO_BD = BigDecimal.fromString("0");
+export const ONE_BD = BigDecimal.fromString("1");
+export const WHITELISTED_TOKEN_ADDRESSES: string[] =
+  "{{ v3.whitelistedTokenAddresses }}".split(",");
+
+export const NATIVE_ADDRESS = "{{ v3.native.address }}";
+
+export const STABLE_TOKEN_ADDRESSES: string[] =
+  "{{ v3.stableTokenAddresses }}".split(",");
+
+export const MINIMUM_ETH_LOCKED = BigDecimal.fromString(
+  "{{ v3.minimumEthLocked }}"
+);
+
+export const NATIVE_PRICE_POOL = Address.fromString("{{ v3.nativePricePool }}")
+  .toHex()
+  .toLowerCase();

--- a/subgraphs/v3-reduced/src/mappings/core.ts
+++ b/subgraphs/v3-reduced/src/mappings/core.ts
@@ -1,0 +1,374 @@
+/* eslint-disable prefer-const */
+import { BigDecimal, BigInt, ethereum } from "@graphprotocol/graph-ts";
+import {
+  Bundle,
+  Burn,
+  Collect,
+  Factory,
+  Mint,
+  Pool,
+  Swap,
+  Token,
+} from "../../generated/schema";
+import {
+  Burn as BurnEvent,
+  Collect as CollectEvent,
+  CollectProtocol as CollectProtocolEvent,
+  Initialize,
+  Mint as MintEvent,
+  SetFeeProtocol as ProtocolFeeEvent,
+  Swap as SwapEvent,
+} from "../../generated/templates/Pool/Pool";
+import { FACTORY_ADDRESS, ONE_BI, ZERO_BD } from "../constants";
+import { convertTokenToDecimal, loadTransaction, safeDiv } from "../utils";
+import {
+  updatePoolDayData,
+  updatePoolHourData,
+  updateUniswapDayData,
+} from "../utils/intervalUpdates";
+import {
+  findEthPerToken,
+  getEthPriceInUSD,
+  getTrackedAmountUSD,
+  sqrtPriceX96ToTokenPrices,
+} from "../utils/pricing";
+
+function saveBuckets(event: ethereum.Event): void {
+  updateUniswapDayData(event).save();
+  updatePoolDayData(event).save();
+  updatePoolHourData(event).save();
+}
+
+export function handleInitialize(event: Initialize): void {
+  let pool = Pool.load(event.address.toHexString()) as Pool;
+  pool.sqrtPrice = event.params.sqrtPriceX96;
+  pool.tick = BigInt.fromI32(event.params.tick);
+  pool.save();
+
+  let token0 = Token.load(pool.token0) as Token;
+  let token1 = Token.load(pool.token1) as Token;
+  let bundle = Bundle.load("1") as Bundle;
+  bundle.ethPriceUSD = getEthPriceInUSD();
+  bundle.save();
+
+  token0.derivedETH = findEthPerToken(token0);
+  token1.derivedETH = findEthPerToken(token1);
+  token0.save();
+  token1.save();
+  updatePoolDayData(event).save();
+  updatePoolHourData(event).save();
+}
+
+export function handleMint(event: MintEvent): void {
+  let bundle = Bundle.load("1") as Bundle;
+  let pool = Pool.load(event.address.toHexString()) as Pool;
+  let factory = Factory.load(FACTORY_ADDRESS.toHex()) as Factory;
+  let token0 = Token.load(pool.token0) as Token;
+  let token1 = Token.load(pool.token1) as Token;
+  let amount0 = convertTokenToDecimal(event.params.amount0, token0.decimals);
+  let amount1 = convertTokenToDecimal(event.params.amount1, token1.decimals);
+  let amountUSD = amount0
+    .times(token0.derivedETH.times(bundle.ethPriceUSD))
+    .plus(amount1.times(token1.derivedETH.times(bundle.ethPriceUSD)));
+
+  factory.totalValueLockedETH = factory.totalValueLockedETH.minus(
+    pool.totalValueLockedETH
+  );
+  factory.txCount = factory.txCount.plus(ONE_BI);
+  pool.txCount = pool.txCount.plus(ONE_BI);
+
+  if (
+    pool.tick !== null &&
+    BigInt.fromI32(event.params.tickLower).le(pool.tick as BigInt) &&
+    BigInt.fromI32(event.params.tickUpper).gt(pool.tick as BigInt)
+  ) {
+    pool.liquidity = pool.liquidity.plus(event.params.amount);
+  }
+
+  pool.totalValueLockedToken0 = pool.totalValueLockedToken0.plus(amount0);
+  pool.totalValueLockedToken1 = pool.totalValueLockedToken1.plus(amount1);
+  pool.totalValueLockedETH = pool.totalValueLockedToken0
+    .times(token0.derivedETH)
+    .plus(pool.totalValueLockedToken1.times(token1.derivedETH));
+  pool.totalValueLockedUSD = pool.totalValueLockedETH.times(bundle.ethPriceUSD);
+  factory.totalValueLockedETH = factory.totalValueLockedETH.plus(
+    pool.totalValueLockedETH
+  );
+  factory.totalValueLockedUSD = factory.totalValueLockedETH.times(
+    bundle.ethPriceUSD
+  );
+
+  let transaction = loadTransaction(event);
+  let mint = new Mint(transaction.id + "-" + event.logIndex.toString());
+  mint.transaction = transaction.id;
+  mint.timestamp = transaction.timestamp;
+  mint.pool = pool.id;
+  mint.owner = event.params.owner;
+  mint.sender = event.params.sender;
+  mint.origin = event.transaction.from;
+  mint.amount = event.params.amount;
+  mint.amount0 = amount0;
+  mint.amount1 = amount1;
+  mint.amountUSD = amountUSD;
+  mint.logIndex = event.logIndex;
+
+  factory.save();
+  pool.save();
+  mint.save();
+  saveBuckets(event);
+}
+
+// Burn does not adjust TVL; the subsequent Collect accounts for withdrawn tokens.
+export function handleBurn(event: BurnEvent): void {
+  let bundle = Bundle.load("1") as Bundle;
+  let pool = Pool.load(event.address.toHexString()) as Pool;
+  let factory = Factory.load(FACTORY_ADDRESS.toHex()) as Factory;
+  let token0 = Token.load(pool.token0) as Token;
+  let token1 = Token.load(pool.token1) as Token;
+  let amount0 = convertTokenToDecimal(event.params.amount0, token0.decimals);
+  let amount1 = convertTokenToDecimal(event.params.amount1, token1.decimals);
+  let amountUSD = amount0
+    .times(token0.derivedETH.times(bundle.ethPriceUSD))
+    .plus(amount1.times(token1.derivedETH.times(bundle.ethPriceUSD)));
+
+  factory.txCount = factory.txCount.plus(ONE_BI);
+  pool.txCount = pool.txCount.plus(ONE_BI);
+  if (
+    pool.tick !== null &&
+    BigInt.fromI32(event.params.tickLower).le(pool.tick as BigInt) &&
+    BigInt.fromI32(event.params.tickUpper).gt(pool.tick as BigInt)
+  ) {
+    pool.liquidity = pool.liquidity.minus(event.params.amount);
+  }
+
+  let transaction = loadTransaction(event);
+  let burn = new Burn(transaction.id + "-" + event.logIndex.toString());
+  burn.transaction = transaction.id;
+  burn.timestamp = transaction.timestamp;
+  burn.pool = pool.id;
+  burn.owner = event.params.owner;
+  burn.origin = event.transaction.from;
+  burn.amount = event.params.amount;
+  burn.amount0 = amount0;
+  burn.amount1 = amount1;
+  burn.amountUSD = amountUSD;
+  burn.logIndex = event.logIndex;
+
+  factory.save();
+  pool.save();
+  burn.save();
+  saveBuckets(event);
+}
+
+export function handleSwap(event: SwapEvent): void {
+  let bundle = Bundle.load("1") as Bundle;
+  let factory = Factory.load(FACTORY_ADDRESS.toHex()) as Factory;
+  let pool = Pool.load(event.address.toHexString()) as Pool;
+  let token0 = Token.load(pool.token0) as Token;
+  let token1 = Token.load(pool.token1) as Token;
+  let amount0 = convertTokenToDecimal(event.params.amount0, token0.decimals);
+  let amount1 = convertTokenToDecimal(event.params.amount1, token1.decimals);
+  let amount0Abs = amount0.lt(ZERO_BD)
+    ? amount0.times(BigDecimal.fromString("-1"))
+    : amount0;
+  let amount1Abs = amount1.lt(ZERO_BD)
+    ? amount1.times(BigDecimal.fromString("-1"))
+    : amount1;
+  let amount0USD = amount0Abs
+    .times(token0.derivedETH)
+    .times(bundle.ethPriceUSD);
+  let amount1USD = amount1Abs
+    .times(token1.derivedETH)
+    .times(bundle.ethPriceUSD);
+  let amountTotalUSDTracked = safeDiv(
+    getTrackedAmountUSD(amount0Abs, token0, amount1Abs, token1),
+    BigDecimal.fromString("2")
+  );
+  let amountTotalUSDUntracked = safeDiv(
+    amount0USD.plus(amount1USD),
+    BigDecimal.fromString("2")
+  );
+  let feesUSD = amountTotalUSDTracked
+    .times(pool.feeTier.toBigDecimal())
+    .div(BigDecimal.fromString("1000000"));
+
+  factory.txCount = factory.txCount.plus(ONE_BI);
+  factory.totalVolumeUSD = factory.totalVolumeUSD.plus(amountTotalUSDTracked);
+  factory.untrackedVolumeUSD = factory.untrackedVolumeUSD.plus(
+    amountTotalUSDUntracked
+  );
+  factory.totalFeesUSD = factory.totalFeesUSD.plus(feesUSD);
+  factory.totalValueLockedETH = factory.totalValueLockedETH.minus(
+    pool.totalValueLockedETH
+  );
+
+  pool.volumeUSD = pool.volumeUSD.plus(amountTotalUSDTracked);
+  pool.txCount = pool.txCount.plus(ONE_BI);
+  pool.liquidity = event.params.liquidity;
+  pool.tick = BigInt.fromI32(event.params.tick as i32);
+  pool.sqrtPrice = event.params.sqrtPriceX96;
+  pool.totalValueLockedToken0 = pool.totalValueLockedToken0.plus(amount0);
+  pool.totalValueLockedToken1 = pool.totalValueLockedToken1.plus(amount1);
+
+  let prices = sqrtPriceX96ToTokenPrices(pool.sqrtPrice, token0, token1);
+  pool.token0Price = prices[0];
+  pool.token1Price = prices[1];
+  // Pricing traverses persisted whitelist pools, so the new pool price must be visible first.
+  pool.save();
+
+  bundle.ethPriceUSD = getEthPriceInUSD();
+  bundle.save();
+  token0.derivedETH = findEthPerToken(token0);
+  token1.derivedETH = findEthPerToken(token1);
+  pool.totalValueLockedETH = pool.totalValueLockedToken0
+    .times(token0.derivedETH)
+    .plus(pool.totalValueLockedToken1.times(token1.derivedETH));
+  pool.totalValueLockedUSD = pool.totalValueLockedETH.times(bundle.ethPriceUSD);
+  factory.totalValueLockedETH = factory.totalValueLockedETH.plus(
+    pool.totalValueLockedETH
+  );
+  factory.totalValueLockedUSD = factory.totalValueLockedETH.times(
+    bundle.ethPriceUSD
+  );
+
+  let transaction = loadTransaction(event);
+  let swap = new Swap(transaction.id + "-" + event.logIndex.toString());
+  swap.transaction = transaction.id;
+  swap.timestamp = transaction.timestamp;
+  swap.pool = pool.id;
+  swap.sender = event.params.sender;
+  swap.origin = event.transaction.from;
+  swap.recipient = event.params.recipient;
+  swap.amount0 = amount0;
+  swap.amount1 = amount1;
+  swap.amountUSD = amountTotalUSDTracked;
+  swap.sqrtPriceX96 = event.params.sqrtPriceX96;
+  swap.logIndex = event.logIndex;
+
+  factory.save();
+  pool.save();
+  token0.save();
+  token1.save();
+  swap.save();
+
+  let protocolDay = updateUniswapDayData(event);
+  protocolDay.volumeUSD = protocolDay.volumeUSD.plus(amountTotalUSDTracked);
+  protocolDay.volumeUSDUntracked = protocolDay.volumeUSDUntracked.plus(
+    amountTotalUSDUntracked
+  );
+  protocolDay.feesUSD = protocolDay.feesUSD.plus(feesUSD);
+
+  let poolDay = updatePoolDayData(event);
+  poolDay.volumeUSD = poolDay.volumeUSD.plus(amountTotalUSDTracked);
+  poolDay.feesUSD = poolDay.feesUSD.plus(feesUSD);
+
+  let poolHour = updatePoolHourData(event);
+  poolHour.volumeUSD = poolHour.volumeUSD.plus(amountTotalUSDTracked);
+  poolHour.feesUSD = poolHour.feesUSD.plus(feesUSD);
+
+  protocolDay.save();
+  poolDay.save();
+  poolHour.save();
+}
+
+export function handlePoolCollect(event: CollectEvent): void {
+  let bundle = Bundle.load("1") as Bundle;
+  let pool = Pool.load(event.address.toHexString());
+  if (pool === null) return;
+  let factory = Factory.load(FACTORY_ADDRESS.toHex()) as Factory;
+  let token0 = Token.load(pool.token0);
+  let token1 = Token.load(pool.token1);
+  if (token0 === null || token1 === null) return;
+
+  let amount0 = convertTokenToDecimal(event.params.amount0, token0.decimals);
+  let amount1 = convertTokenToDecimal(event.params.amount1, token1.decimals);
+  let amountUSD = getTrackedAmountUSD(amount0, token0, amount1, token1);
+  factory.totalValueLockedETH = factory.totalValueLockedETH.minus(
+    pool.totalValueLockedETH
+  );
+  factory.txCount = factory.txCount.plus(ONE_BI);
+  pool.txCount = pool.txCount.plus(ONE_BI);
+  pool.totalValueLockedToken0 = pool.totalValueLockedToken0.minus(amount0);
+  pool.totalValueLockedToken1 = pool.totalValueLockedToken1.minus(amount1);
+  pool.totalValueLockedETH = pool.totalValueLockedToken0
+    .times(token0.derivedETH)
+    .plus(pool.totalValueLockedToken1.times(token1.derivedETH));
+  pool.totalValueLockedUSD = pool.totalValueLockedETH.times(bundle.ethPriceUSD);
+  factory.totalValueLockedETH = factory.totalValueLockedETH.plus(
+    pool.totalValueLockedETH
+  );
+  factory.totalValueLockedUSD = factory.totalValueLockedETH.times(
+    bundle.ethPriceUSD
+  );
+
+  let transaction = loadTransaction(event);
+  let collect = new Collect(transaction.id + "-" + event.logIndex.toString());
+  collect.transaction = transaction.id;
+  collect.timestamp = event.block.timestamp;
+  collect.pool = pool.id;
+  collect.owner = event.params.owner;
+  collect.amount0 = amount0;
+  collect.amount1 = amount1;
+  collect.amountUSD = amountUSD;
+  collect.logIndex = event.logIndex;
+
+  factory.save();
+  pool.save();
+  collect.save();
+  saveBuckets(event);
+}
+
+export function handleProtocolCollect(event: CollectProtocolEvent): void {
+  let bundle = Bundle.load("1") as Bundle;
+  let pool = Pool.load(event.address.toHexString());
+  if (pool === null) return;
+  let factory = Factory.load(FACTORY_ADDRESS.toHex()) as Factory;
+  let token0 = Token.load(pool.token0);
+  let token1 = Token.load(pool.token1);
+  if (token0 === null || token1 === null) return;
+
+  let amount0 = convertTokenToDecimal(event.params.amount0, token0.decimals);
+  let amount1 = convertTokenToDecimal(event.params.amount1, token1.decimals);
+  let amountUSD = getTrackedAmountUSD(amount0, token0, amount1, token1);
+  factory.totalValueLockedETH = factory.totalValueLockedETH.minus(
+    pool.totalValueLockedETH
+  );
+  factory.txCount = factory.txCount.plus(ONE_BI);
+  pool.txCount = pool.txCount.plus(ONE_BI);
+  pool.totalValueLockedToken0 = pool.totalValueLockedToken0.minus(amount0);
+  pool.totalValueLockedToken1 = pool.totalValueLockedToken1.minus(amount1);
+  pool.totalValueLockedETH = pool.totalValueLockedToken0
+    .times(token0.derivedETH)
+    .plus(pool.totalValueLockedToken1.times(token1.derivedETH));
+  pool.totalValueLockedUSD = pool.totalValueLockedETH.times(bundle.ethPriceUSD);
+  factory.totalValueLockedETH = factory.totalValueLockedETH.plus(
+    pool.totalValueLockedETH
+  );
+  factory.totalValueLockedUSD = factory.totalValueLockedETH.times(
+    bundle.ethPriceUSD
+  );
+
+  let transaction = loadTransaction(event);
+  let collect = new Collect(transaction.id + "-" + event.logIndex.toString());
+  collect.transaction = transaction.id;
+  collect.timestamp = event.block.timestamp;
+  collect.pool = pool.id;
+  collect.owner = event.params.recipient;
+  collect.amount0 = amount0;
+  collect.amount1 = amount1;
+  collect.amountUSD = amountUSD;
+  collect.logIndex = event.logIndex;
+
+  factory.save();
+  pool.save();
+  collect.save();
+  saveBuckets(event);
+}
+
+export function handleSetProtocolFee(event: ProtocolFeeEvent): void {
+  let pool = Pool.load(event.address.toHexString());
+  if (pool === null) return;
+  pool.isProtocolFeeEnabled =
+    event.params.feeProtocol0New > 0 || event.params.feeProtocol1New > 0;
+  pool.save();
+}

--- a/subgraphs/v3-reduced/src/mappings/factory.ts
+++ b/subgraphs/v3-reduced/src/mappings/factory.ts
@@ -1,0 +1,111 @@
+/* eslint-disable prefer-const */
+import { BigInt, log } from "@graphprotocol/graph-ts";
+import { PoolCreated } from "../../generated/Factory/Factory";
+import { Bundle, Factory, Pool, Token } from "../../generated/schema";
+import { Pool as PoolTemplate } from "../../generated/templates";
+import {
+  FACTORY_ADDRESS,
+  WHITELISTED_TOKEN_ADDRESSES,
+  ZERO_BD,
+  ZERO_BI,
+} from "../constants";
+import {
+  fetchTokenDecimals,
+  fetchTokenName,
+  fetchTokenSymbol,
+  fetchTokenTotalSupply,
+} from "../utils/token";
+
+export function handlePoolCreated(event: PoolCreated): void {
+  let factory = Factory.load(FACTORY_ADDRESS.toHex());
+  if (factory === null) {
+    factory = new Factory(FACTORY_ADDRESS.toHex());
+    factory.txCount = ZERO_BI;
+    factory.totalVolumeUSD = ZERO_BD;
+    factory.untrackedVolumeUSD = ZERO_BD;
+    factory.totalFeesUSD = ZERO_BD;
+    factory.totalValueLockedETH = ZERO_BD;
+    factory.totalValueLockedUSD = ZERO_BD;
+
+    let bundle = new Bundle("1");
+    bundle.ethPriceUSD = ZERO_BD;
+    bundle.save();
+  }
+
+  let pool = new Pool(event.params.pool.toHexString());
+  let token0 = Token.load(event.params.token0.toHexString());
+  let token1 = Token.load(event.params.token1.toHexString());
+
+  if (token0 === null) {
+    let symbol = fetchTokenSymbol(event.params.token0);
+    let name = fetchTokenName(event.params.token0);
+    let totalSupply = fetchTokenTotalSupply(event.params.token0);
+    let decimals = fetchTokenDecimals(event.params.token0);
+    if (decimals === null) {
+      log.warning("Unable to load decimals for token {}", [
+        event.params.token0.toHexString(),
+      ]);
+      return;
+    }
+    token0 = new Token(event.params.token0.toHexString());
+    token0.symbol = symbol;
+    token0.name = name;
+    token0.decimals = decimals;
+    token0.totalSupply = totalSupply;
+    token0.derivedETH = ZERO_BD;
+    token0.whitelistPools = [];
+  }
+
+  if (token1 === null) {
+    let symbol = fetchTokenSymbol(event.params.token1);
+    let name = fetchTokenName(event.params.token1);
+    let totalSupply = fetchTokenTotalSupply(event.params.token1);
+    let decimals = fetchTokenDecimals(event.params.token1);
+    if (decimals === null) {
+      log.warning("Unable to load decimals for token {}", [
+        event.params.token1.toHexString(),
+      ]);
+      return;
+    }
+    token1 = new Token(event.params.token1.toHexString());
+    token1.symbol = symbol;
+    token1.name = name;
+    token1.decimals = decimals;
+    token1.totalSupply = totalSupply;
+    token1.derivedETH = ZERO_BD;
+    token1.whitelistPools = [];
+  }
+
+  if (WHITELISTED_TOKEN_ADDRESSES.includes(token0.id)) {
+    let pools = token1.whitelistPools;
+    pools.push(pool.id);
+    token1.whitelistPools = pools;
+  }
+  if (WHITELISTED_TOKEN_ADDRESSES.includes(token1.id)) {
+    let pools = token0.whitelistPools;
+    pools.push(pool.id);
+    token0.whitelistPools = pools;
+  }
+
+  pool.token0 = token0.id;
+  pool.token1 = token1.id;
+  pool.feeTier = BigInt.fromI32(event.params.fee);
+  pool.createdAtTimestamp = event.block.timestamp;
+  pool.txCount = ZERO_BI;
+  pool.liquidity = ZERO_BI;
+  pool.sqrtPrice = ZERO_BI;
+  pool.token0Price = ZERO_BD;
+  pool.token1Price = ZERO_BD;
+  pool.totalValueLockedToken0 = ZERO_BD;
+  pool.totalValueLockedToken1 = ZERO_BD;
+  pool.totalValueLockedUSD = ZERO_BD;
+  pool.totalValueLockedETH = ZERO_BD;
+  pool.volumeUSD = ZERO_BD;
+  pool.isProtocolFeeEnabled = false;
+
+  pool.save();
+  PoolTemplate.create(event.params.pool);
+  token0.save();
+  token1.save();
+  factory.save();
+}

--- a/subgraphs/v3-reduced/src/utils/index.ts
+++ b/subgraphs/v3-reduced/src/utils/index.ts
@@ -1,0 +1,45 @@
+/* eslint-disable prefer-const */
+import { BigDecimal, BigInt, ethereum } from "@graphprotocol/graph-ts";
+import { Transaction } from "../../generated/schema";
+import { ONE_BI, ZERO_BD, ZERO_BI } from "../constants";
+
+export function exponentToBigDecimal(decimals: BigInt): BigDecimal {
+  let result = BigDecimal.fromString("1");
+  for (let i = ZERO_BI; i.lt(decimals); i = i.plus(ONE_BI)) {
+    result = result.times(BigDecimal.fromString("10"));
+  }
+  return result;
+}
+
+export function safeDiv(
+  numerator: BigDecimal,
+  denominator: BigDecimal
+): BigDecimal {
+  return denominator.equals(ZERO_BD) ? ZERO_BD : numerator.div(denominator);
+}
+
+export function convertTokenToDecimal(
+  amount: BigInt,
+  decimals: BigInt
+): BigDecimal {
+  return decimals.equals(ZERO_BI)
+    ? amount.toBigDecimal()
+    : amount.toBigDecimal().div(exponentToBigDecimal(decimals));
+}
+
+export function isNullEthValue(value: string): boolean {
+  return value == "0x0000000000000000000000000000000000000000000000000000000000000001";
+}
+
+// Transactions are immutable shared envelopes. Multiple pool events in the
+// same transaction reuse the first entity instead of rewriting identical data.
+export function loadTransaction(event: ethereum.Event): Transaction {
+  let transaction = Transaction.load(event.transaction.hash.toHexString());
+  if (transaction === null) {
+    transaction = new Transaction(event.transaction.hash.toHexString());
+    transaction.blockNumber = event.block.number;
+    transaction.timestamp = event.block.timestamp;
+    transaction.save();
+  }
+  return transaction as Transaction;
+}

--- a/subgraphs/v3-reduced/src/utils/intervalUpdates.ts
+++ b/subgraphs/v3-reduced/src/utils/intervalUpdates.ts
@@ -1,0 +1,73 @@
+/* eslint-disable prefer-const */
+import { ethereum } from "@graphprotocol/graph-ts";
+import {
+  Factory,
+  Pool,
+  PoolDayData,
+  PoolHourData,
+  UniswapDayData,
+} from "../../generated/schema";
+import { FACTORY_ADDRESS, ONE_BI, ZERO_BD, ZERO_BI } from "../constants";
+
+// Interval helpers deliberately do not save. Handlers finish all mutations and
+// persist each bucket once, avoiding the previous double-write on every swap.
+export function updateUniswapDayData(event: ethereum.Event): UniswapDayData {
+  let factory = Factory.load(FACTORY_ADDRESS.toHex()) as Factory;
+  let timestamp = event.block.timestamp.toI32();
+  let dayID = timestamp / 86400;
+  let dayData = UniswapDayData.load(dayID.toString());
+
+  if (dayData === null) {
+    dayData = new UniswapDayData(dayID.toString());
+    dayData.date = dayID * 86400;
+    dayData.volumeUSD = ZERO_BD;
+    dayData.volumeUSDUntracked = ZERO_BD;
+    dayData.feesUSD = ZERO_BD;
+  }
+
+  dayData.tvlUSD = factory.totalValueLockedUSD;
+  dayData.txCount = factory.txCount;
+  return dayData as UniswapDayData;
+}
+
+export function updatePoolDayData(event: ethereum.Event): PoolDayData {
+  let timestamp = event.block.timestamp.toI32();
+  let dayID = timestamp / 86400;
+  let id = event.address.toHexString().concat("-").concat(dayID.toString());
+  let pool = Pool.load(event.address.toHexString()) as Pool;
+  let dayData = PoolDayData.load(id);
+
+  if (dayData === null) {
+    dayData = new PoolDayData(id);
+    dayData.date = dayID * 86400;
+    dayData.pool = pool.id;
+    dayData.volumeUSD = ZERO_BD;
+    dayData.feesUSD = ZERO_BD;
+    dayData.txCount = ZERO_BI;
+  }
+
+  dayData.tvlUSD = pool.totalValueLockedUSD;
+  dayData.txCount = dayData.txCount.plus(ONE_BI);
+  return dayData as PoolDayData;
+}
+
+export function updatePoolHourData(event: ethereum.Event): PoolHourData {
+  let timestamp = event.block.timestamp.toI32();
+  let hourID = timestamp / 3600;
+  let id = event.address.toHexString().concat("-").concat(hourID.toString());
+  let pool = Pool.load(event.address.toHexString()) as Pool;
+  let hourData = PoolHourData.load(id);
+
+  if (hourData === null) {
+    hourData = new PoolHourData(id);
+    hourData.periodStartUnix = hourID * 3600;
+    hourData.pool = pool.id;
+    hourData.volumeUSD = ZERO_BD;
+    hourData.feesUSD = ZERO_BD;
+    hourData.txCount = ZERO_BI;
+  }
+
+  hourData.tvlUSD = pool.totalValueLockedUSD;
+  hourData.txCount = hourData.txCount.plus(ONE_BI);
+  return hourData as PoolHourData;
+}

--- a/subgraphs/v3-reduced/src/utils/pricing.ts
+++ b/subgraphs/v3-reduced/src/utils/pricing.ts
@@ -1,0 +1,151 @@
+/* eslint-disable prefer-const */
+import {
+  MINIMUM_ETH_LOCKED,
+  NATIVE_ADDRESS,
+  NATIVE_PRICE_POOL,
+  ONE_BD,
+  STABLE_TOKEN_ADDRESSES,
+  WHITELISTED_TOKEN_ADDRESSES,
+  ZERO_BD,
+  ZERO_BI,
+} from "../constants";
+import { Bundle, Pool, Token } from "../../generated/schema";
+import { BigDecimal, BigInt } from "@graphprotocol/graph-ts";
+import { exponentToBigDecimal, safeDiv } from "../utils/index";
+
+const Q192 = BigInt.fromI32(2).pow(BigInt.fromI32(192).toI32() as u8);
+
+export function sqrtPriceX96ToTokenPrices(
+  sqrtPriceX96: BigInt,
+  token0: Token,
+  token1: Token
+): BigDecimal[] {
+  let num = sqrtPriceX96.times(sqrtPriceX96).toBigDecimal();
+  let denom = Q192.toBigDecimal();
+  let price1 = num
+    .div(denom)
+    .times(exponentToBigDecimal(token0.decimals))
+    .div(exponentToBigDecimal(token1.decimals));
+
+  let price0 = safeDiv(BigDecimal.fromString("1"), price1);
+  return [price0, price1];
+}
+
+export function getEthPriceInUSD(): BigDecimal {
+  // fetch eth prices for each stablecoin
+  let nativeAndStablePool = Pool.load(NATIVE_PRICE_POOL);
+
+  if (nativeAndStablePool !== null) {
+    return nativeAndStablePool.token0 == NATIVE_ADDRESS.toLowerCase()
+      ? nativeAndStablePool.token1Price
+      : nativeAndStablePool.token0Price;
+  } else {
+    return ZERO_BD;
+  }
+}
+
+/**
+ * Search through graph to find derived Eth per token.
+ * @todo update to be derived ETH (add stablecoin estimates)
+ **/
+export function findEthPerToken(token: Token): BigDecimal {
+  if (token.id == NATIVE_ADDRESS.toLowerCase()) {
+    return ONE_BD;
+  }
+  let whiteList = token.whitelistPools;
+  // for now just take USD from pool with greatest TVL
+  // need to update this to actually detect best rate based on liquidity distribution
+  let largestLiquidityETH = ZERO_BD;
+  let priceSoFar = ZERO_BD;
+  let bundle = Bundle.load("1") as Bundle;
+
+  // hardcoded fix for incorrect rates
+  // if whitelist includes token - get the safe price
+  if (STABLE_TOKEN_ADDRESSES.includes(token.id)) {
+    priceSoFar = safeDiv(ONE_BD, bundle.ethPriceUSD);
+  } else {
+    for (let i = 0; i < whiteList.length; ++i) {
+      let poolAddress = whiteList[i];
+      let pool = Pool.load(poolAddress) as Pool;
+
+      if (pool.liquidity.gt(ZERO_BI)) {
+        if (pool.token0 == token.id) {
+          // whitelist token is token1
+          let token1 = Token.load(pool.token1) as Token;
+          // get the derived ETH in pool
+          let ethLocked = pool.totalValueLockedToken1.times(token1.derivedETH);
+          if (
+            ethLocked.gt(largestLiquidityETH) &&
+            ethLocked.gt(MINIMUM_ETH_LOCKED)
+          ) {
+            largestLiquidityETH = ethLocked;
+            // token1 per our token * Eth per token1
+            priceSoFar = pool.token1Price.times(
+              token1.derivedETH as BigDecimal
+            );
+          }
+        }
+        if (pool.token1 == token.id) {
+          let token0 = Token.load(pool.token0) as Token;
+          // get the derived ETH in pool
+          let ethLocked = pool.totalValueLockedToken0.times(token0.derivedETH);
+          if (
+            ethLocked.gt(largestLiquidityETH) &&
+            ethLocked.gt(MINIMUM_ETH_LOCKED)
+          ) {
+            largestLiquidityETH = ethLocked;
+            // token0 per our token * ETH per token0
+            priceSoFar = pool.token0Price.times(
+              token0.derivedETH as BigDecimal
+            );
+          }
+        }
+      }
+    }
+  }
+  return priceSoFar; // nothing was found return 0
+}
+
+/**
+ * Accepts tokens and amounts, return tracked amount based on token whitelist
+ * If one token on whitelist, return amount in that token converted to USD * 2.
+ * If both are, return sum of two amounts
+ * If neither is, return 0
+ */
+export function getTrackedAmountUSD(
+  tokenAmount0: BigDecimal,
+  token0: Token,
+  tokenAmount1: BigDecimal,
+  token1: Token
+): BigDecimal {
+  let bundle = Bundle.load("1") as Bundle;
+  let price0USD = token0.derivedETH.times(bundle.ethPriceUSD);
+  let price1USD = token1.derivedETH.times(bundle.ethPriceUSD);
+
+  // both are whitelist tokens, return sum of both amounts
+  if (
+    WHITELISTED_TOKEN_ADDRESSES.includes(token0.id) &&
+    WHITELISTED_TOKEN_ADDRESSES.includes(token1.id)
+  ) {
+    return tokenAmount0.times(price0USD).plus(tokenAmount1.times(price1USD));
+  }
+
+  // take double value of the whitelisted token amount
+  if (
+    WHITELISTED_TOKEN_ADDRESSES.includes(token0.id) &&
+    !WHITELISTED_TOKEN_ADDRESSES.includes(token1.id)
+  ) {
+    return tokenAmount0.times(price0USD).times(BigDecimal.fromString("2"));
+  }
+
+  // take double value of the whitelisted token amount
+  if (
+    !WHITELISTED_TOKEN_ADDRESSES.includes(token0.id) &&
+    WHITELISTED_TOKEN_ADDRESSES.includes(token1.id)
+  ) {
+    return tokenAmount1.times(price1USD).times(BigDecimal.fromString("2"));
+  }
+
+  // neither token is on white list, tracked amount is 0
+  return ZERO_BD;
+}

--- a/subgraphs/v3-reduced/src/utils/staticTokenDefinition.ts
+++ b/subgraphs/v3-reduced/src/utils/staticTokenDefinition.ts
@@ -1,0 +1,100 @@
+import { Address, BigInt } from "@graphprotocol/graph-ts";
+
+// Static decimal fallbacks for historical tokens whose contracts do not
+// implement the standard ERC20 metadata interface.
+export class StaticTokenDefinition {
+  address: Address;
+  symbol: string;
+  name: string;
+  decimals: BigInt;
+
+  constructor(
+    address: Address,
+    symbol: string,
+    name: string,
+    decimals: BigInt
+  ) {
+    this.address = address;
+    this.symbol = symbol;
+    this.name = name;
+    this.decimals = decimals;
+  }
+
+  // Get all tokens with a static defintion
+  static getStaticDefinitions(): Array<StaticTokenDefinition> {
+    let staticDefinitions = new Array<StaticTokenDefinition>(6);
+
+    // Add DGD
+    let tokenDGD = new StaticTokenDefinition(
+      Address.fromString("0xe0b7927c4af23765cb51314a0e0521a9645f0e2a"),
+      "DGD",
+      "DGD",
+      BigInt.fromI32(9)
+    );
+    staticDefinitions.push(tokenDGD);
+
+    // Add AAVE
+    let tokenAAVE = new StaticTokenDefinition(
+      Address.fromString("0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9"),
+      "AAVE",
+      "Aave Token",
+      BigInt.fromI32(18)
+    );
+    staticDefinitions.push(tokenAAVE);
+
+    // Add LIF
+    let tokenLIF = new StaticTokenDefinition(
+      Address.fromString("0xeb9951021698b42e4399f9cbb6267aa35f82d59d"),
+      "LIF",
+      "Lif",
+      BigInt.fromI32(18)
+    );
+    staticDefinitions.push(tokenLIF);
+
+    // Add SVD
+    let tokenSVD = new StaticTokenDefinition(
+      Address.fromString("0xbdeb4b83251fb146687fa19d1c660f99411eefe3"),
+      "SVD",
+      "savedroid",
+      BigInt.fromI32(18)
+    );
+    staticDefinitions.push(tokenSVD);
+
+    // Add TheDAO
+    let tokenTheDAO = new StaticTokenDefinition(
+      Address.fromString("0xbb9bc244d798123fde783fcc1c72d3bb8c189413"),
+      "TheDAO",
+      "TheDAO",
+      BigInt.fromI32(16)
+    );
+    staticDefinitions.push(tokenTheDAO);
+
+    // Add HPB
+    let tokenHPB = new StaticTokenDefinition(
+      Address.fromString("0x38c6a68304cdefb9bec48bbfaaba5c5b47818bb2"),
+      "HPB",
+      "HPBCoin",
+      BigInt.fromI32(18)
+    );
+    staticDefinitions.push(tokenHPB);
+
+    return staticDefinitions;
+  }
+
+  // Helper for hardcoded tokens
+  static fromAddress(tokenAddress: Address): StaticTokenDefinition | null {
+    let staticDefinitions = this.getStaticDefinitions();
+    let tokenAddressHex = tokenAddress.toHexString();
+
+    // Search the definition using the address
+    for (let i = 0; i < staticDefinitions.length; i++) {
+      let staticDefinition = staticDefinitions[i];
+      if (staticDefinition.address.toHexString() == tokenAddressHex) {
+        return staticDefinition;
+      }
+    }
+
+    // If not found, return null
+    return null;
+  }
+}

--- a/subgraphs/v3-reduced/src/utils/token.ts
+++ b/subgraphs/v3-reduced/src/utils/token.ts
@@ -1,0 +1,80 @@
+/* eslint-disable prefer-const */
+import { Address, BigInt } from "@graphprotocol/graph-ts";
+import { ERC20 } from "../../generated/Factory/ERC20";
+import { ERC20NameBytes } from "../../generated/Factory/ERC20NameBytes";
+import { ERC20SymbolBytes } from "../../generated/Factory/ERC20SymbolBytes";
+import { NETWORK, ZERO_BI } from "../constants";
+import { isNullEthValue } from ".";
+import { StaticTokenDefinition } from "./staticTokenDefinition";
+
+export function fetchTokenSymbol(tokenAddress: Address): string {
+  let contract = ERC20.bind(tokenAddress);
+  let contractSymbolBytes = ERC20SymbolBytes.bind(tokenAddress);
+  let symbolValue = "unknown";
+  let symbolResult = contract.try_symbol();
+
+  if (symbolResult.reverted) {
+    let symbolResultBytes = contractSymbolBytes.try_symbol();
+    if (!symbolResultBytes.reverted) {
+      if (!isNullEthValue(symbolResultBytes.value.toHexString())) {
+        symbolValue = symbolResultBytes.value.toString();
+      } else {
+        let definition = StaticTokenDefinition.fromAddress(tokenAddress);
+        if (definition !== null) {
+          symbolValue = definition.symbol;
+        }
+      }
+    }
+  } else {
+    symbolValue = symbolResult.value;
+  }
+
+  return symbolValue;
+}
+
+export function fetchTokenName(tokenAddress: Address): string {
+  let contract = ERC20.bind(tokenAddress);
+  let contractNameBytes = ERC20NameBytes.bind(tokenAddress);
+  let nameValue = "unknown";
+  let nameResult = contract.try_name();
+
+  if (nameResult.reverted) {
+    let nameResultBytes = contractNameBytes.try_name();
+    if (!nameResultBytes.reverted) {
+      if (!isNullEthValue(nameResultBytes.value.toHexString())) {
+        nameValue = nameResultBytes.value.toString();
+      } else {
+        let definition = StaticTokenDefinition.fromAddress(tokenAddress);
+        if (definition !== null) {
+          nameValue = definition.name;
+        }
+      }
+    }
+  } else {
+    nameValue = nameResult.value;
+  }
+
+  return nameValue;
+}
+
+export function fetchTokenTotalSupply(tokenAddress: Address): BigInt {
+  let result = ERC20.bind(tokenAddress).try_totalSupply();
+  return result.reverted ? ZERO_BI : result.value;
+}
+
+export function fetchTokenDecimals(tokenAddress: Address): BigInt {
+  let result = ERC20.bind(tokenAddress).try_decimals();
+  if (!result.reverted) {
+    return BigInt.fromI32(result.value);
+  }
+
+  if (NETWORK == "mainnet") {
+    let definition = StaticTokenDefinition.fromAddress(tokenAddress);
+    if (definition !== null) {
+      return definition.decimals;
+    }
+  }
+
+  // Match the existing v3 behavior for non-standard tokens.
+  return BigInt.fromI32(18);
+}

--- a/subgraphs/v3-reduced/template.yaml
+++ b/subgraphs/v3-reduced/template.yaml
@@ -1,0 +1,65 @@
+specVersion: 1.2.0
+{{#graft}}
+features:
+  - grafting
+{{/graft}}
+schema:
+  file: ./schema{{#graftSchema}}.graft{{/graftSchema}}.graphql
+indexerHints:
+  prune: auto
+dataSources:
+  - kind: ethereum/contract
+    name: Factory
+    network: {{ network }}
+    source:
+      address: "{{ v3.factory.address }}"
+      startBlock: {{ v3.factory.startBlock }}
+      abi: Factory
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      file: ./src/mappings/factory.ts
+      entities: []
+      abis:
+        - name: Factory
+          file: ./abis/factory.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: ERC20SymbolBytes
+          file: ./abis/ERC20SymbolBytes.json
+        - name: ERC20NameBytes
+          file: ./abis/ERC20NameBytes.json
+      eventHandlers:
+        - event: PoolCreated(indexed address,indexed address,indexed uint24,int24,address)
+          handler: handlePoolCreated
+templates:
+  - kind: ethereum/contract
+    name: Pool
+    network: {{ network }}
+    source:
+      abi: Pool
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      file: ./src/mappings/core.ts
+      entities: []
+      abis:
+        - name: Pool
+          file: ./abis/pool.json
+      eventHandlers:
+        - event: Initialize(uint160,int24)
+          handler: handleInitialize
+        - event: Swap(indexed address,indexed address,int256,int256,uint160,uint128,int24)
+          handler: handleSwap
+        - event: Mint(address,indexed address,indexed int24,indexed int24,uint128,uint256,uint256)
+          handler: handleMint
+        - event: Burn(indexed address,indexed int24,indexed int24,uint128,uint256,uint256)
+          handler: handleBurn
+        - event: Collect(indexed address,address,indexed int24,indexed int24,uint128,uint128)
+          handler: handlePoolCollect
+        - event: CollectProtocol(indexed address,indexed address,uint128,uint128)
+          handler: handleProtocolCollect
+        - event: SetFeeProtocol(uint8,uint8,uint8,uint8)
+          handler: handleSetProtocolFee

--- a/subgraphs/v3-reduced/tsconfig.json
+++ b/subgraphs/v3-reduced/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../config/tsconfig.json",
+  "include": ["src", "generated", "tests"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": ["ES2016"],
+    "rootDirs": ["./src", "./generated", "./tests"]
+  }
+}


### PR DESCRIPTION
## Summary

- add a separate `v3-reduced` implementation for data-api workloads
- retain pool discovery, TVL, volume, pool/protocol buckets, transaction events, and token metadata
- remove positions, snapshots, tick entities/buckets, token buckets, flash data, and fee-growth indexing
- keep the high-frequency Swap handler free of contract calls
- support immutable and mutable graft builds plus a clean-build fallback

## Robinhood deployment

- deployment: `sushiswap/v3-reduced-robinhood`
- graft source: `sushiswap/v3-robinhood`
- graft block: `33716960`
- immutable event schema graft succeeded
- live endpoint is healthy, indexing without errors, and returns restored token metadata

## Verification

- `NETWORK=robinhood pnpm --filter v3-reduced generate:immutable-graft`
- `pnpm --filter v3-reduced build`
- `git diff --check`
- live GraphQL query for `_meta` and token `symbol`, `name`, `decimals`, and `totalSupply`